### PR TITLE
Don't use workflow_run for publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,11 +1,8 @@
 name: publish
 
 on:
-  workflow_run:
-    workflows: [ci]
+  push:
     branches: [main]
-    types:
-      - completed
     
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
I don't like how worklows triggered in this manner do not show up on
the commit it was triggered for. Might probably revist and think of a
better way to do this, I'm clearly missing something obvious but it's
almost midnight and I couldn't care less lol
